### PR TITLE
feat(validator): Array shorthand syntax

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+# Always validate the PR title, and ignore the commits
+titleOnly: true

--- a/README.md
+++ b/README.md
@@ -184,14 +184,17 @@ const matthewCar = carValidator({
 
 ### array
 
-Creates a schema that matches arrays containing values specified by the schemas passed in the array.
+Creates a schema that matches arrays containing values specified by the schemas passed as parameters.
 
 ```ts
-const musicGenresSchema = array([string()]);
+const musicGenresSchema = array(string());
 const musicGenresValidator = validate(musicGenresSchema);
 
 // Returns ['classical', 'lofi', 'pop']
 const musicGenres = musicGenresValidator(['classical', 'lofi', 'pop']);
+
+const primitiveValidator = validate(array(string(), number(), boolean()));
+primitiveValidator([false, 'string', 123, 42, ':)']); // OK
 ```
 
 ### Modifiers

--- a/__tests__/index.test-d.ts
+++ b/__tests__/index.test-d.ts
@@ -84,21 +84,21 @@ const nested2 = object({
 });
 expectType<{ readonly a: string; readonly b: { readonly c: number } }>(validate(nested2)({}));
 
-const nested3 = array([]);
+const nested3 = array();
 expectType<readonly never[]>(validate(nested3)([]));
 
-const nested4 = array([string()]);
+const nested4 = array(string());
 expectType<readonly string[]>(validate(nested4)([]));
 
-const nested5 = array([string(), optional(number())]);
+const nested5 = array(string(), optional(number()));
 expectType<readonly (string | number | undefined)[]>(validate(nested5)([]));
 
-const nested6 = optional(array([string(), number()]));
+const nested6 = optional(array(string(), number()));
 expectType<readonly (string | number)[] | undefined>(validate(nested6)([]));
 
 const nested7 = optional(
   object({
-    arr: optional(array([string(), number()])),
+    arr: optional(array(string(), number())),
   }),
 );
 expectType<

--- a/__tests__/property-tests.spec.ts
+++ b/__tests__/property-tests.spec.ts
@@ -127,7 +127,7 @@ describe('@typeofweb/schema', () => {
               object({
                 a: number(),
                 b: string(),
-                c: array([number(), string(), boolean()]),
+                c: array(number(), string(), boolean()),
                 d: object({ e: string() }),
               }),
             ),
@@ -144,7 +144,7 @@ describe('@typeofweb/schema', () => {
               object({
                 a: number(),
                 b: string(),
-                c: array([string()]),
+                c: array(string()),
                 d: object({ e: string() }),
               }),
             ),

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -179,7 +179,7 @@ export const object = <U extends Record<string, AnySchema>>(obj: U) => {
   >;
 };
 
-export const array = <U extends readonly AnySchema[]>(arr: readonly [...U]) => {
+export const array = <U extends readonly AnySchema[]>(...arr: readonly [...U]) => {
   return {
     __validator: arr,
     __type: {} as unknown,


### PR DESCRIPTION
Resolves #4 

BREAKING CHANGE: Removed old array syntax: `array([string()])` is no longer valid. Use `array(string())` instead.
