### PR TITLE
fix(performance): Analyse and fix performance deopt in node.js

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,17 +3,6 @@ import type { AnySchema } from './types';
 export const isDate = (d: unknown): d is Date =>
   Object.prototype.toString.call(d) === '[object Date]';
 
-export const fromEntries = (entries: readonly (readonly [string | number, any])[]) => {
-  const obj: Record<keyof any, any> = {};
-  // eslint-disable-next-line functional/no-loop-statement
-  for (let i = 0; i < entries.length; ++i) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    obj[entries[i]![0]] = entries[i]![1];
-  }
-
-  return obj;
-};
-
 type Modifier<S1, S2> = (arg: S1) => S2;
 type SchemaArg<S> = (() => S) | S;
 // prettier-ignore

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -142,8 +142,8 @@ export const object = <U extends Record<string, AnySchema>>(obj: U) => {
   return {
     [TYPEOFWEB_SCHEMA]: true,
     __validator: obj,
-    __type: {} as unknown,
     __modifiers: { optional: false, nullable: false },
+    __type: {} as unknown,
     __values: {} as unknown,
   } as Schema<
     {
@@ -159,8 +159,8 @@ export const array = <U extends readonly AnySchema[]>(...arr: readonly [...U]) =
   return {
     [TYPEOFWEB_SCHEMA]: true,
     __validator: arr,
-    __type: {} as unknown,
     __modifiers: { optional: false, nullable: false },
+    __type: {} as unknown,
     __values: {} as unknown,
   } as Schema<
     readonly TypeOf<U[number]>[],


### PR DESCRIPTION
## Before
| library                     | relative speed | operations per second | avg. operation time |
| --------------------------- | -------------: | --------------------: | ------------------: |
| **@typeofweb/schema@0.4.2** |         **0%** |   **(1,187,900 rps)** |  **(avg: 0.841μs)** |
| mschema@0.5.6               |        -51.96% |         (570,698 rps) |          (avg: 1μs) |
| validator.js@2.0.4          |        -58.61% |         (491,630 rps) |          (avg: 2μs) |
| validate.js@0.13.1          |        -79.14% |         (247,790 rps) |          (avg: 4μs) |
| validatorjs@3.22.1          |        -85.98% |         (166,501 rps) |          (avg: 6μs) |
| joi@17.3.0                  |        -89.58% |         (123,763 rps) |          (avg: 8μs) |
| superstruct@0.13.3          |        -94.69% |          (63,099 rps) |         (avg: 15μs) |
| yup@0.32.8                  |        -94.64% |          (63,711 rps) |         (avg: 15μs) |
| jsonschema@1.4.0            |        -96.85% |          (37,471 rps) |         (avg: 26μs) |
| parambulator@1.5.2          |        -98.08% |          (22,823 rps) |         (avg: 43μs) |

## After
| library                     | relative speed | operations per second | avg. operation time |
| --------------------------- | -------------: | --------------------: | ------------------: |
| **@typeofweb/schema@0.4.2** |         **0%** |   **(1,443,686 rps)** |  **(avg: 0.692μs)** |
| mschema@0.5.6               |        -58.95% |         (592,589 rps) |          (avg: 1μs) |
| validator.js@2.0.4          |        -66.32% |         (486,197 rps) |          (avg: 2μs) |
| validate.js@0.13.1          |        -84.03% |         (230,496 rps) |          (avg: 4μs) |
| validatorjs@3.22.1          |        -88.67% |         (163,587 rps) |          (avg: 6μs) |
| joi@17.3.0                  |        -91.15% |         (127,809 rps) |          (avg: 7μs) |
| superstruct@0.13.3          |        -95.59% |          (63,604 rps) |         (avg: 15μs) |
| yup@0.32.8                  |        -96.06% |          (56,823 rps) |         (avg: 17μs) |
| jsonschema@1.4.0            |        -97.24% |          (39,834 rps) |         (avg: 25μs) |
| parambulator@1.5.2          |        -98.38% |          (23,428 rps) |         (avg: 42μs) |