### PR TITLE
Not a change in code. Only a reproducible example on a side effect

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "rollup-plugin-license": "2.3.0",
     "rollup-plugin-prettier": "2.1.0",
     "rollup-plugin-terser": "7.0.2",
+    "terser": "^5.6.1",
     "ts-jest": "26.5.4",
     "tsd": "https://github.com/typeofweb/tsd#pkg",
     "tslib": "2.1.0",
@@ -74,7 +75,8 @@
     "test": "yarn jest",
     "jest": "jest --detectOpenHandles --forceExit --passWithNoTests --coverage",
     "build": "rimraf dist && rollup --config",
-    "prepublishOnly": "yarn build"
+    "prepublishOnly": "yarn build",
+    "example": "yarn tsc src/example.ts && terser --compress --mangle --toplevel -- src/example.js"
   },
   "husky": {
     "hooks": {

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,0 +1,4 @@
+import './errors'; // is not removed
+
+const b = 'will be removed';
+export const a = `stays as it's an export`;

--- a/src/example.ts
+++ b/src/example.ts
@@ -1,4 +1,9 @@
-import './errors'; // is not removed
+import { ValidationError } from './errors'; // is not removed
+
+export const a = `stays as it's an export`;
 
 const b = 'will be removed';
-export const a = `stays as it's an export`;
+
+function object() {
+  new ValidationError({} as any, {});
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6054,6 +6054,15 @@ terser@^5.6.0:
     source-map "~0.7.2"
     source-map-support "~0.5.19"
 
+terser@^5.6.1:
+  version "5.6.1"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.6.1.tgz#a48eeac5300c0a09b36854bf90d9c26fb201973c"
+  integrity sha512-yv9YLFQQ+3ZqgWCUk+pvNJwgUTdlIxUk1WTN+RnaFJe2L7ipG2csPT0ra2XRm7Cs8cxN7QXmK1rFzEwYEQkzXw==
+  dependencies:
+    commander "^2.20.0"
+    source-map "~0.7.2"
+    source-map-support "~0.5.19"
+
 test-exclude@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz"


### PR DESCRIPTION
## Related to

- https://github.com/typeofweb/schema/issues/52

## How to run it

Please:
- pull & install deps
- run `yarn example`
  - it will print to CLI the processed src/example.js: unused variable would be removed, but an unused class won't
    - the ValidationError will stay