### PR TITLE
feat(errors): ValidationError contains all error details array #13

### DIFF
--- a/__tests__/errors.spec.ts
+++ b/__tests__/errors.spec.ts
@@ -1,0 +1,134 @@
+import {
+  number,
+  object,
+  string,
+  validate,
+  date,
+  pipe,
+  ValidationError,
+  minStringLength,
+} from '../src';
+import type { ErrorDetails } from '../src/errors';
+
+const expectToMatchError = (fn: () => any, details?: ErrorDetails) => {
+  try {
+    fn();
+  } catch (err) {
+    if (err instanceof ValidationError) {
+      return expect(err.details).toEqual(details);
+    }
+    throw err;
+  }
+  fail();
+};
+
+describe('errors', () => {
+  it('should list fields in object which are incorrect', () => {
+    const validator = pipe(
+      object({
+        validString: string(),
+        invalidNumber: number(),
+        validNumber: number(),
+        invalidString: string(),
+        validDate: date(),
+        invalidDate: date(),
+      }),
+      validate,
+    );
+
+    expectToMatchError(
+      () =>
+        validator({
+          validString: 'aaa',
+          invalidNumber: 'vvvv',
+          validNumber: 123,
+          invalidString: 1333,
+          validDate: new Date('2020'),
+          invalidDate: 'no siema eniu',
+        }),
+      [
+        {
+          path: 'invalidNumber',
+          expected: 'number',
+          got: 'vvvv',
+        },
+        {
+          path: 'invalidString',
+          expected: 'string',
+          got: 1333,
+        },
+        {
+          path: 'invalidDate',
+          expected: 'date',
+          got: 'no siema eniu',
+        },
+      ],
+    );
+  });
+
+  it('should contain args field', () => {
+    const validator = pipe(
+      object({
+        tooShortString: minStringLength(10)(),
+      })(),
+      validate,
+    );
+    expectToMatchError(
+      () =>
+        validator({
+          tooShortString: 'too short',
+        }),
+      [
+        {
+          path: 'tooShortString',
+          expected: 'minStringLength',
+          got: 'too short',
+          args: [10],
+        },
+      ],
+    );
+  });
+
+  it('should list nested objects which are undefined', () => {
+    const validator = pipe(
+      object({
+        invalidNumber: number(),
+        nested: object({
+          invalidString: string(),
+          deeper: object({
+            invalidDate: date(),
+          })(),
+        })(),
+      }),
+      validate,
+    );
+
+    expectToMatchError(
+      () =>
+        validator({
+          nested: {
+            deeper: {
+              invalidDate: 'I really like this library!',
+            },
+          },
+        }),
+      [
+        {
+          path: 'nested.deeper.invalidDate',
+          expected: 'date',
+          got: 'I really like this library!',
+        },
+        {
+          path: 'nested.invalidString',
+          expected: 'string',
+          got: undefined,
+        },
+        {
+          path: 'invalidNumber',
+          expected: 'number',
+          got: undefined,
+        },
+      ],
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -70,9 +70,10 @@
     "weak-napi": "2.0.2"
   },
   "scripts": {
-    "pretest": "yarn build",
-    "test": "yarn jest",
-    "jest": "jest --detectOpenHandles --forceExit --passWithNoTests --coverage",
+    "prejest": "yarn build",
+    "jest": "jest",
+    "test": "yarn jest --detectOpenHandles --forceExit --passWithNoTests --coverage",
+    "test:dev": "yarn jest --watch",
     "build": "rimraf dist && rollup --config",
     "prepublishOnly": "yarn build"
   },

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,21 +1,70 @@
 import { schemaToString } from './stringify';
-import type { SomeSchema } from './types';
+import type { Either, SomeSchema } from './types';
+
+export interface ErrorData {
+  readonly expected: string;
+  readonly got: unknown;
+}
+
+export class ErrorDataBasic implements ErrorData {
+  constructor(public readonly expected: string, public readonly got: unknown) {}
+}
+
+export class ErrorDataArgs implements ErrorData {
+  constructor(
+    public readonly expected: string,
+    public readonly got: unknown,
+    public readonly args: ReadonlyArray<unknown>,
+  ) {}
+}
+
+export class ObjectErrorAttr {
+  constructor(public readonly path: string, public readonly error: ErrorData) {}
+}
+
+export class ErrorDataObject implements ErrorData {
+  constructor(
+    public readonly expected: string,
+    public readonly got: unknown,
+    public readonly errors: ReadonlyArray<ObjectErrorAttr>,
+  ) {}
+}
+
+type ErrorInfo = ErrorDataBasic | ErrorDataObject | ErrorDataArgs;
+
+function toErrorWithPath(error: ErrorDataBasic | ErrorDataArgs, path: string) {
+  return {
+    path,
+    ...error,
+  };
+}
+
+function objectErrorAttrToInfo(error: ObjectErrorAttr, path?: string): ErrorDetails {
+  const newPath = path ? `${path}.${error.path}` : error.path;
+  if (error.error instanceof ErrorDataObject) {
+    return error.error.errors.flatMap((e) => objectErrorAttrToInfo(e, newPath));
+  }
+  return toErrorWithPath(error.error, newPath);
+}
+
+function errorInfoToArray(errorData: ErrorInfo): ErrorDetails {
+  if (errorData instanceof ErrorDataObject) {
+    return errorData.errors.flatMap((error) => objectErrorAttrToInfo(error));
+  }
+  return errorData;
+}
 
 export class ValidationError extends Error {
-  public readonly details: ErrorDetails;
+  public readonly details?: ErrorDetails;
 
-  constructor(schema: SomeSchema<any>, value: any) {
+  constructor(schema: SomeSchema<any>, value: any, errorData: Either<never>) {
     const expected = schemaToString(schema);
     const got = typeof value === 'function' ? String(value) : JSON.stringify(value);
 
-    const details: ErrorDetails = {
-      kind: 'TYPE_MISMATCH',
-      got,
-      expected,
-    };
-    super(`Invalid type! Expected ${details.expected} but got ${details.got}!`);
+    super(`Invalid type! Expected ${expected} but got ${got}!`);
 
-    this.details = details;
+    this.details = errorInfoToArray(errorData.value);
+
     this.name = 'ValidationError';
     Error.captureStackTrace(this);
 
@@ -23,8 +72,12 @@ export class ValidationError extends Error {
   }
 }
 
-type ErrorDetails = {
-  readonly kind: 'TYPE_MISMATCH';
+export type ErrorDetail = {
   readonly expected: string;
-  readonly got: string;
+  readonly got: unknown;
+  readonly path?: string;
+  readonly args?: ReadonlyArray<unknown>;
+  readonly errors?: ReadonlyArray<ErrorDetail>;
 };
+
+export type ErrorDetails = ErrorDetail | ReadonlyArray<ErrorDetail>;

--- a/src/modifiers/minArrayLength.ts
+++ b/src/modifiers/minArrayLength.ts
@@ -1,3 +1,4 @@
+import { ErrorDataArgs } from '../errors';
 import { refine } from '../refine';
 import type { TupleOf } from '../types';
 
@@ -10,5 +11,5 @@ export const minArrayLength = <L extends number>(minLength: L) =>
             ...(readonly typeof value[number][])
           ],
         )
-      : t.left(value);
+      : t.left(new ErrorDataArgs('minArrayLength', value, [minLength]));
   });

--- a/src/modifiers/minStringLength.ts
+++ b/src/modifiers/minStringLength.ts
@@ -1,4 +1,9 @@
+import { ErrorDataArgs } from '../errors';
 import { refine } from '../refine';
 
 export const minStringLength = <L extends number>(minLength: L) =>
-  refine((value: string, t) => (value.length >= minLength ? t.nextValid(value) : t.left(value)));
+  refine((value: string, t) =>
+    value.length >= minLength
+      ? t.nextValid(value)
+      : t.left(new ErrorDataArgs('minStringLength', value, [minLength])),
+  );

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { ValidationError } from './errors';
+import type { ErrorData } from './errors';
 
 export type TypeOf<S extends SomeSchema<any>> = Pretty<S['__type']>;
 
@@ -18,7 +18,7 @@ export type Next<Output> =
   | { readonly _t: 'nextNotValid'; readonly value: Output }
   | { readonly _t: 'nextValid'; readonly value: Output };
 
-export type Either<R, L = ValidationError> = Left<L> | Right<R>;
+export type Either<R, L = ErrorData> = Left<L> | Right<R>;
 
 export type SomeSchema<T> = Schema<T>;
 

--- a/src/validators/__validate.ts
+++ b/src/validators/__validate.ts
@@ -7,7 +7,7 @@ export const validate = <S extends SomeSchema<unknown>>(schema: S) => (value: un
   if (result._t === 'right' || result._t === 'nextValid') {
     return result.value as TypeOf<S>;
   } else {
-    // throw result.value;
-    throw new ValidationError(schema, value);
+    // @ts-expect-error fix this
+    throw new ValidationError(schema, value, result);
   }
 };

--- a/src/validators/boolean.ts
+++ b/src/validators/boolean.ts
@@ -1,10 +1,11 @@
+import { ErrorDataBasic } from '../errors';
 import { refine } from '../refine';
 import { typeToPrint } from '../stringify';
 
 export const boolean = refine(
   (value, t) => {
     if (typeof value !== 'boolean') {
-      return t.left(value);
+      return t.left(new ErrorDataBasic('boolean', value));
     }
     return t.nextValid(value);
   },

--- a/src/validators/date.ts
+++ b/src/validators/date.ts
@@ -1,3 +1,4 @@
+import { ErrorDataBasic } from '../errors';
 import { refine } from '../refine';
 import { typeToPrint } from '../stringify';
 import { isDate, isISODateString } from '../utils/dateUtils';
@@ -6,7 +7,7 @@ export const date = refine(
   (value, t) => {
     const parsedValue = parseDate(value);
     if (!isDate(parsedValue) || Number.isNaN(Number(parsedValue))) {
-      return t.left(parsedValue);
+      return t.left(new ErrorDataBasic('date', value));
     }
     return t.nextValid(parsedValue);
   },

--- a/src/validators/number.ts
+++ b/src/validators/number.ts
@@ -1,16 +1,14 @@
+import { ErrorDataBasic } from '../errors';
 import { refine } from '../refine';
 import { typeToPrint } from '../stringify';
 
-export const number = refine(
-  (value, t) => {
-    const parsedValue = parseNumber(value);
-    if (typeof parsedValue !== 'number' || Number.isNaN(parsedValue)) {
-      return t.left(parsedValue);
-    }
-    return t.nextValid(parsedValue);
-  },
-  () => typeToPrint('number'),
-);
+export const number = refine((value, t) => {
+  const parsedValue = parseNumber(value);
+  if (typeof parsedValue !== 'number' || Number.isNaN(parsedValue)) {
+    return t.left(new ErrorDataBasic('number', value));
+  }
+  return t.nextValid(parsedValue);
+}, numberToString);
 
 function parseNumber(value: unknown) {
   if (typeof value === 'string') {
@@ -20,4 +18,8 @@ function parseNumber(value: unknown) {
     return Number(value);
   }
   return value;
+}
+
+function numberToString() {
+  return typeToPrint('number');
 }

--- a/src/validators/oneOf.ts
+++ b/src/validators/oneOf.ts
@@ -1,4 +1,5 @@
 /* eslint-disable functional/no-loop-statement */
+import { ErrorDataBasic } from '../errors';
 import { refine } from '../refine';
 import { isSchema } from '../schema';
 import { schemaToString } from '../stringify';
@@ -31,7 +32,7 @@ export const oneOf = <U extends readonly (Primitives | SomeSchema<any>)[]>(
           }
         }
       }
-      return t.left(value as TypeOfResult);
+      return t.left(new ErrorDataBasic('oneOf', value as TypeOfResult));
     },
     () => {
       const str = validatorsOrLiterals

--- a/src/validators/string.ts
+++ b/src/validators/string.ts
@@ -1,3 +1,4 @@
+import { ErrorDataBasic } from '../errors';
 import { refine } from '../refine';
 import { typeToPrint } from '../stringify';
 import { isDate } from '../utils/dateUtils';
@@ -6,7 +7,7 @@ export const string = refine(
   (value, t) => {
     const parsedValue = parseString(value);
     if (typeof parsedValue !== 'string') {
-      return t.left(parsedValue);
+      return t.left(new ErrorDataBasic('string', value));
     }
     return t.nextValid(parsedValue);
   },

--- a/src/validators/tuple.ts
+++ b/src/validators/tuple.ts
@@ -1,5 +1,5 @@
 /* eslint-disable functional/no-loop-statement */
-import { ValidationError } from '../errors';
+import { ErrorDataBasic, ValidationError } from '../errors';
 import { refine } from '../refine';
 import { isSchema } from '../schema';
 import { schemaToString } from '../stringify';
@@ -34,7 +34,9 @@ export const tuple = <U extends readonly (Primitives | SomeSchema<any>)[]>(
             result[i] = value;
             continue;
           } else {
-            result[i] = new ValidationError(this, validatorsOrLiterals);
+            // TODO: not sure what to do here actually
+            // @ts-expect-error
+            result[i] = new ValidationError(this, validatorsOrLiterals, {});
             isError = true;
             continue;
           }
@@ -42,7 +44,7 @@ export const tuple = <U extends readonly (Primitives | SomeSchema<any>)[]>(
       }
 
       if (isError) {
-        return t.left((result as unknown) as TypeOfResult);
+        return t.left(new ErrorDataBasic('tuple', values));
       }
       return t.nextValid((result as unknown) as TypeOfResult);
     },


### PR DESCRIPTION
Fixes #13 

This PR implements all error details attached to ValidationError. See `__tests__/errors.spec.ts` to see how it works.

I hope this will allow creating any custom error messages we can think of. I focused on knowing:
* What specific validation has failed
* What arguments were used to create that validation
* What was the received value

There are small problems with types - help appreciated. Also, I'm open to API and naming change propositions.